### PR TITLE
Fixes issue when passing values directly to setter

### DIFF
--- a/src/Rule/CleanCode/DataStructureMethods.php
+++ b/src/Rule/CleanCode/DataStructureMethods.php
@@ -131,8 +131,11 @@ class DataStructureMethods extends AbstractDataStructure
         $methods = $node->findChildrenOfType('MethodPostfix');
 
         foreach ($methods as $method) {
-            if ('set' === substr($method->getImage(), 0, 3) && '$this' === $method->getFirstChildOfType('Variable')->getImage()) {
-                $count++;
+            if ('set' === substr($method->getImage(), 0, 3)) {
+                $child = $method->getFirstChildOfType('Variable');
+                if($child && '$this' === $child->getImage()) {
+                    $count++;
+                }
             }
         }
 


### PR DESCRIPTION
There's an issue in the case values are passed directly to the setter params :
$dateTime->setDate(1955, 04, 18);
The method $method->getFirstChildOfType('Variable') returns null.